### PR TITLE
docs(ReadMe): change the name of one env-variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_USER=postgres
 DB_PASSWORD=test
-DB_NAME=peer
+DB_DATABASE=peer
 ```
 
 ### **6. Generate Security Keys**


### PR DESCRIPTION
I made a small mistake in the ReadMe file:
DB_NAME
should actually be
DB_DATABASE