### PR TITLE
fix(umlauts): umlauts not displaying correctly. 

### DIFF
--- a/src/Middleware/HtmlentityDecoderMiddleware.php
+++ b/src/Middleware/HtmlentityDecoderMiddleware.php
@@ -61,7 +61,7 @@ class HtmlentityDecoderMiddleware implements MiddlewareInterface
             }
         } elseif (is_string($data)) {
             if(in_array($key, static::DECODE_ENTITY_COLUMNS)){
-                $data = html_entity_decode(htmlspecialchars_decode($data), ENT_NOQUOTES, 'UTF-8');
+                $data = html_entity_decode(htmlspecialchars_decode($data), ENT_QUOTES, 'UTF-8');
             }
         }
 

--- a/src/Middleware/HtmlentityDecoderMiddleware.php
+++ b/src/Middleware/HtmlentityDecoderMiddleware.php
@@ -10,6 +10,20 @@ use Slim\Psr7\Stream;
 
 class HtmlentityDecoderMiddleware implements MiddlewareInterface
 {
+    /**
+     * Recursively decode HTML entities columns
+     * 
+     * Add more columns here for decode html entity
+     */
+    protected const DECODE_ENTITY_COLUMNS = [
+        'title', 
+        'mediadescription', 
+        'content', 
+        'comments', 
+        'message', 
+        'name'
+    ];
+
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $response = $handler->handle($request);
@@ -39,14 +53,16 @@ class HtmlentityDecoderMiddleware implements MiddlewareInterface
     /**
      * Recursively decode HTML entities in all string values
      */
-    private function decodeHtmlEntities($data)
+    private function decodeHtmlEntities($data, $key = '')
     {
         if (is_array($data)) {
             foreach ($data as $key => &$value) {
-                $value = $this->decodeHtmlEntities($value);
+                $value = $this->decodeHtmlEntities($value, $key);
             }
         } elseif (is_string($data)) {
-            $data = html_entity_decode(htmlspecialchars_decode($data), ENT_NOQUOTES, 'UTF-8');
+            if(in_array($key, static::DECODE_ENTITY_COLUMNS)){
+                $data = html_entity_decode(htmlspecialchars_decode($data), ENT_NOQUOTES, 'UTF-8');
+            }
         }
 
         return $data;

--- a/src/Middleware/HtmlentityDecoderMiddleware.php
+++ b/src/Middleware/HtmlentityDecoderMiddleware.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Fawaz\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Slim\Psr7\Stream;
+
+class HtmlentityDecoderMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $response = $handler->handle($request);
+
+        // Get response body content as a string
+        $body = (string) $response->getBody();
+
+        // Decode JSON
+        $data = json_decode($body, true);
+
+        // If valid JSON, decode HTML entities in all strings
+        if ($data !== null) {
+            $data = $this->decodeHtmlEntities($data);
+
+            $decodedBody = json_encode($data);
+
+            $stream = fopen('php://temp', 'r+');
+            fwrite($stream, $decodedBody);
+            rewind($stream);
+
+            return $response->withBody(new Stream($stream));
+        }
+
+        return $response;
+    }
+
+    /**
+     * Recursively decode HTML entities in all string values
+     */
+    private function decodeHtmlEntities($data)
+    {
+        if (is_array($data)) {
+            foreach ($data as $key => &$value) {
+                $value = $this->decodeHtmlEntities($value);
+            }
+        } elseif (is_string($data)) {
+            $data = html_entity_decode(htmlspecialchars_decode($data), ENT_NOQUOTES, 'UTF-8');
+        }
+
+        return $data;
+    }
+}

--- a/src/config/middleware.php
+++ b/src/config/middleware.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Fawaz\Middleware\HtmlentityDecoderMiddleware;
 use Slim\App;
 use Psr\Container\ContainerInterface;
 use Fawaz\Middleware\RateLimiterMiddleware;
@@ -27,6 +28,9 @@ return static function (App $app, ContainerInterface $container, array $settings
 
     // Register the SecurityHeadersMiddleware
     $app->add(SecurityHeadersMiddleware::class);
+
+    // Add Middleware for Decode special character HTML entities
+    $app->add(HtmlentityDecoderMiddleware::class);
 
     // Add the error middleware
     $app->addErrorMiddleware(true, true, true);


### PR DESCRIPTION
**ClickUp Task**: [86c2g4ta2](https://app.clickup.com/t/86c2g4ta2)

#### Issue:  
When creating records in the database, special characters (such as Umlauts) were stored using HTML entities due to the use of `htmlspecialchars` and HTML encoding. However, the response logic did not include decoding, leading to incorrect character rendering on the client side.  

#### Solution:  
To resolve this issue, a new middleware, `HtmlentityDecoderMiddleware`, has been implemented. This middleware ensures that encoded HTML entities are properly decoded before sending responses, restoring correct character representation.  

#### Affected Fields:  
This fix has been applied to selected columns, including:  
- `title`  
- `mediadescription`  
- `content`  
- `comments`  
- `message`  
- `name`  

This improvement ensures that special characters display correctly across the application.