### PR TITLE
fix(chat with non-friends): no new message will be sent to non-friends

### DIFF
--- a/src/App/ChatService.php
+++ b/src/App/ChatService.php
@@ -531,6 +531,31 @@ class ChatService
         }
 
         try {
+
+            if ($chat && $chat->getIsPublic() == 0) {
+                $participants = $this->chatMapper->getParticipants($chatId);
+
+                if(count($participants) === 2){
+                    // Find the recipients
+                    $friends = $this->getFriends();
+
+                    // Check if $friends is an array and has follow
+                    if (!is_array($friends) || empty($friends)) {
+                        return $this->respondWithError("You can't send a message because mutual following is not there.");
+                    }
+                    $friendIds = array_column($friends, 'uid');
+
+                    $participants = array_column($participants, 'userid', 'userid');
+                    unset($participants[$this->currentUserId]);
+
+                    foreach ($participants as $participantId) {
+                        if (!in_array($participantId, $friendIds)) {
+                            return $this->respondWithError("You can't send a message because mutual following is not there.");
+                        }
+                    }
+                }
+            }
+
             $messageData = [
                 'messid' => 0,
                 'chatid' => $chatId,

--- a/src/Database/ChatMapper.php
+++ b/src/Database/ChatMapper.php
@@ -970,4 +970,17 @@ class ChatMapper
             return false;
         }
     }
+
+    public function getParticipants(string $chatId)
+    {
+        $this->logger->info("ChatMapper.getParticipants started");
+
+        $sql = "SELECT * FROM chatparticipants WHERE chatid = :chatId";
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute(['chatId' => $chatId]);
+        $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return ($data);
+    }
+    
 }


### PR DESCRIPTION
ClickUp Task: https://app.clickup.com/t/86c2gv7dq

### Issue:
When sending message to Non-friends (users are not following each other) message still got saved on database.

### Solution:
Implemented Logic to verify if chat participants follows each other or not.

### Affected files:
`src/App/ChatService.php`
`src/Database/ChatMapper.php`