### PR TITLE
fix(tagsearch): add validation and give message for empty records

### DIFF
--- a/src/App/TagService.php
+++ b/src/App/TagService.php
@@ -125,10 +125,16 @@ class TagService
         $this->logger->info("TagService.loadTag started");
 
         try {
+
+            if(isset($args['tagname'])){
+                if (!$this->isValidTagName(strtolower($args['tagname']))) {
+                    return $this->respondWithError('Invalid string format. Must be contain only letters and 2-50 letters long.');
+                }
+            }
             $tags = $this->tagMapper->searchByName($args);
 
-            if ($tags === false) {
-                return $this->respondWithError('Failed to fetch tags from database.');
+            if (empty($tags) && count($tags) === 0) {
+                return $this->respondWithError('No tags found including this string.');
             }
 
             $this->logger->info("TagService.loadTag successfully fetched tags", [

--- a/src/Database/TagMapper.php
+++ b/src/Database/TagMapper.php
@@ -115,7 +115,7 @@ class TagMapper
                 return $tags;
             }
 
-            return false;
+            return [];
 
         } catch (\PDOException $e) {
             $this->logger->error("Error fetching tags from database", [


### PR DESCRIPTION
ClickUp: [86c2gva98](https://app.clickup.com/t/86c2gva98)

### Issue:
When searching by tag name, the system does not validate the input string properly. If the tag does not exist in the database, it returns an inconsistent or incorrect response message.

### Solution:
- Implement validation for the tag name to ensure it contains only valid characters.
- Return a clear and appropriate response message when the tag is not found.

### Affected files:
`src/App/TagService.php`
`src/Database/TagMapper.php`
 