### PR TITLE
fix(no comment response): modify response when no parent comment found

### DIFF
--- a/src/GraphQLSchemaBuilder.php
+++ b/src/GraphQLSchemaBuilder.php
@@ -1519,15 +1519,17 @@ class GraphQLSchemaBuilder
         }
         
         $comments = $this->commentService->fetchByParentId($args);
-        $results = array_map(fn(CommentAdvanced $comment) => $comment->getArrayCopy(), $comments);
+        if(is_array($comments) && count($comments) > 0){
+            $results = array_map(fn(CommentAdvanced $comment) => $comment->getArrayCopy(), $comments);
         
-        if ($results !== false) {
-            return [
-                'status' => 'success',
-                'counter' => count($results),
-                'ResponseCode' => 'Success get comments',
-                'affectedRows' => $results,
-            ];
+            if ($results !== false) {
+                return [
+                    'status' => 'success',
+                    'counter' => count($results),
+                    'ResponseCode' => 'Success get comments',
+                    'affectedRows' => $results,
+                ];
+            }
         }
 
         return $this->respondWithError('No comments found');


### PR DESCRIPTION
### Issue:  
Currently, when retrieving the parent comments of a given comment, the system returns a generic success message (`"Success get comments"`) even when no comments are found. Instead, it should return a more accurate response indicating that no comments are available.  

### Solution:  
To ensure the correct response, the `$comments` variable should be checked for content. If it is empty, the system should return a `"No comment found"` message along with a count of `0`.  

### Affected File:  
- `src/GraphQLSchemaBuilder.php`