### PR TITLE
feat: add automatic thumbnail generation for video posts using ffmpeg

### DIFF
--- a/src/Services/ThumbnailGeneratorService.php
+++ b/src/Services/ThumbnailGeneratorService.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Services;
+
+use Ramsey\Uuid\Uuid;
+
+class ThumbnailGeneratorService
+{
+    private string $outputDir;
+
+    public function __construct()
+    {
+        $this->outputDir = base_path('runtime-data/media/cover');
+
+        if (!is_dir($this->outputDir)) {
+            mkdir($this->outputDir, 0755, true);
+        }
+    }
+
+    public function generateFromVideo(string $videoPath, string $coverFilename = null): ?array
+    {
+        if (!file_exists($videoPath)) {
+            throw new \Exception("Video file not found: $videoPath");
+        }
+
+        $filename = $coverFilename ?? Uuid::uuid4()->toString() . '.jpg';
+        $fullPath = $this->outputDir . '/' . $filename;
+
+        // Get duration
+        $durationCmd = "ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 " . escapeshellarg($videoPath);
+        $duration = (float) trim(shell_exec($durationCmd));
+        $randomSecond = ($duration <= 1) ? 1 : rand(1, (int) floor($duration - 1));
+
+        // Generate thumbnail
+        $command = "ffmpeg -y -i " . escapeshellarg($videoPath) .
+            " -ss 00:00:" . str_pad((string) $randomSecond, 2, '0', STR_PAD_LEFT) .
+            ".000 -vframes 1 " . escapeshellarg($fullPath);
+        shell_exec($command);
+
+        if (!file_exists($fullPath)) {
+            return null;
+        }
+
+        [$width, $height] = getimagesize($fullPath);
+        $size = filesize($fullPath);
+
+        return [
+            'path' => '/media/cover/' . $filename,
+            'options' => [
+                'size' => round($size / 1048576, 2) . ' MB',
+                'resolution' => $width . 'x' . $height,
+            ]
+        ];
+    }
+}

--- a/src/Services/VideoPostService.php
+++ b/src/Services/VideoPostService.php
@@ -1,23 +1,49 @@
 <?php
 
-namespace Fawaz\Services;
+namespace App\Services;
+
+use App\Utils\Base64FileHandler;
+use App\Services\ThumbnailGeneratorService;
 
 class VideoPostService
 {
     private Base64FileHandler $fileHandler;
+    private ThumbnailGeneratorService $thumbnailService;
 
     public function __construct()
     {
         $this->fileHandler = new Base64FileHandler();
+        $this->thumbnailService = new ThumbnailGeneratorService();
     }
 
-    public function getErrors(): array
+    public function handleFileUpload(string $base64Video, string $videoId, ?array $existingCover = null): array
     {
-        return $this->fileHandler->getErrors();
-    }
+        // 1. Saving the video to Disk
+        $uploadResult = $this->fileHandler->handleFileUpload(
+            $base64Video,
+            'video',
+            $videoId,
+            'video'
+        );
 
-    public function handleFileUpload(string $base64Video, string $videoId): array
-    {
-        return $this->fileHandler->handleFileUpload($base64Video, 'video', $videoId, 'video');
+        $videoPath = public_path($uploadResult['path']);
+
+        // 2. If the cover already exists, we don't do anything.
+        if ($existingCover !== null) {
+            $uploadResult['cover'] = $existingCover;
+            return $uploadResult;
+        }
+
+        // 3. Generating the cover
+        try {
+            $coverData = $this->thumbnailService->generateFromVideo($videoPath);
+            if ($coverData) {
+                $uploadResult['cover'] = $coverData;
+            }
+        } catch (\Exception $e) {
+            \Log::error('Thumbnail generation failed: ' . $e->getMessage());
+        }
+
+        return $uploadResult;
     }
 }


### PR DESCRIPTION
Feature: Automatic Video Thumbnail Generation

What’s included:

- `ThumbnailGeneratorService` generates thumbnails using ffmpeg.
- Pulls a random frame based on video duration (via ffprobe).
- Stores cover in `runtime-data/media/cover` as `{uuid}.jpg`.
- Returns the full structure:

