### PR TITLE
fix(GetChat): return success and code 21801 when no chat is found

### DIFF
--- a/src/App/ChatService.php
+++ b/src/App/ChatService.php
@@ -637,9 +637,14 @@ class ChatService
 
             $result = $this->chatMapper->loadChatById($this->currentUserId, $args);
 
-            if ($result['status'] !== 'success') {
-                throw new ValidationException($result['ResponseCode']);
-            }
+           // WE INSERT this check here
+if (empty($result['data']) || empty($result['data']['chat'])) {
+    return [
+        'status' => 'success',
+        'ResponseCode' => 21801,
+        'data' => null,
+    ];
+    }
 
             $chatData = $result['data'];
 


### PR DESCRIPTION
Task: Update GetChat to return status: "success" and code: 21801 when no chat is found.

- Previously, the system returned an error with code 40301.
- Now, if no chat exists, the response is:
  {
    "status": "success",
    "ResponseCode": 21801,
    "data": null
  }

This fix avoids treating "no chat found" as an error and brings it in line with expected success behavior for empty results.
