### PR TITLE
fix(GetPostInfo): return success status and code 11502 when no posts …

### DIFF
--- a/src/GraphQLSchemaBuilder.php
+++ b/src/GraphQLSchemaBuilder.php
@@ -2684,15 +2684,22 @@ class GraphQLSchemaBuilder
         $postId = isset($postId) ? trim($postId) : '';
 
         if (!empty($postId)) {
-            $posts = $this->postInfoService->findPostInfo($postId);
-            if (isset($posts['status']) && $posts['status'] === 'error') {
-                return $posts;
-            }
-        } else {
-            return $this->respondWithError(21504);
-        }
+    $posts = $this->postInfoService->findPostInfo(postId: $postId);
+    if (isset($posts['status']) && $posts['status'] === 'error') {
+        return $posts;
+    }
+}
 
-        return $this->createSuccessResponse(11502, $posts);
+if (empty($posts['data'])) {
+    return [
+        'status' => 'success',
+        'ResponseCode' => 11502,
+        'data' => null,
+    ];
+}
+
+return $this->createSuccessResponse(message: 11502, data: $posts);
+
     }
 
     protected function resolveCommentInfo(string $commentId): ?array


### PR DESCRIPTION
…found

## Summary

This PR updates the `resolvePostInfo` GraphQL resolver to return a proper **success response** with code `11502` when no post data is found.

---

##Behavior Updated

### Before:
- When no post was found, returned:
  ```php
  return $this->respondWithError(message: 21504);
