### PR TITLE
fix(GetChat): restore status validation and return success for empty …

### DIFF
--- a/src/App/ChatService.php
+++ b/src/App/ChatService.php
@@ -638,8 +638,15 @@ class ChatService
             $result = $this->chatMapper->loadChatById($this->currentUserId, $args);
 
             if ($result['status'] !== 'success') {
-                throw new ValidationException($result['ResponseCode']);
-            }
+            throw new ValidationException($result['ResponseCode']);
+    } 
+            if (empty($result['data']) || empty($result['data']['chat'])) {
+            return [
+                'status' => 'success',
+                'ResponseCode' => 21801,
+                'data' => null,
+            ];
+    }
 
             $chatData = $result['data'];
 


### PR DESCRIPTION
…chat (code 21801)

- Re-added check for `$result['status'] !== 'success'` with ValidationException,
  as required for error propagation from chatMapper layer.
- Added handling for the case when `$result['data']['chat']` is empty,
  returning status "success" with response code 21801 and null data.
- Final response includes properly structured Chat object when data exists.

This aligns the function with expected contract: 
errors are still thrown when necessary, but "no chat found" is treated as a valid success case.