### PR TITLE
added Timestamp.txt so deploy pages dont skip and added a message to …

### DIFF
--- a/.github/workflows/Newman_backend_test.yaml
+++ b/.github/workflows/Newman_backend_test.yaml
@@ -814,7 +814,7 @@ jobs:
   send_success_discord_notification:
     name: Send Discord Notification for Successful CI
     runs-on: ubuntu-latest
-    needs: [aggregate_outcome, publish_success_report_to_pages]
+    needs: [aggregate_outcome, publish_success_report_to_pages, trivy_scan]
     if: needs.aggregate_outcome.outputs.final_outcome == 'success'
     steps:
       - name: Construct HTMLExtra report URLs

--- a/.github/workflows/Newman_backend_test.yaml
+++ b/.github/workflows/Newman_backend_test.yaml
@@ -667,7 +667,10 @@ jobs:
         with:
           name: docker_newman_report-8.3
           path: reports/${{ github.run_id }}/php-8.3
-        
+
+      - name: Add timestamp to force commit
+        run: echo "Last updated $(date)" > reports/${{ github.run_id }}/timestamp.txt
+ 
       - name: Commit and push reports
         run: |
           git config user.name "github-actions"
@@ -724,6 +727,9 @@ jobs:
         with:
           name: docker_newman_report-8.3
           path: reports/${{ github.run_id }}/php-8.3
+
+      - name: Add timestamp to force commit
+        run: echo "Last updated $(date)" > reports/${{ github.run_id }}/timestamp.txt
  
       - name: Commit and push reports
         run: |
@@ -766,6 +772,7 @@ jobs:
           MESSAGE+="PHP 8.3 Report: <$PHP83_URL>\n"
           MESSAGE+="Maintainer: <@1362087975906967736>\n"
           MESSAGE+="Author: $DISCORD_MENTION"
+          MESSAGE+="\n **Note**: Reports may take up to 10 minutes to appear due to GitHub Pages deployment delays. You can download Artifacts in the Actions tab to view the HTMLExtra report immediately."
  
           curl -H "Content-Type: application/json" \
                -X POST \
@@ -797,6 +804,7 @@ jobs:
           MESSAGE+="CI Run: <$RUN_URL>\n"
           MESSAGE+="Maintainer: $MAINTAINER_MENTION\n"
           MESSAGE+="Author: $PR_MENTION"
+          MESSAGE+="\n **Note**: Reports may take up to 10 minutes to appear due to GitHub Pages deployment delays. You can download Artifacts in the Actions tab to view the HTMLExtra report immediately."
  
           curl -H "Content-Type: application/json" \
                -X POST \
@@ -832,6 +840,7 @@ jobs:
           MESSAGE+="PHP 8.2 Report: <$PHP82_URL>\n"
           MESSAGE+="PHP 8.3 Report: <$PHP83_URL>\n"
           MESSAGE+="<@1355093873323671742>"  # vidkazan
+          MESSAGE+="\n **Note**: Reports may take up to 10 minutes to appear due to GitHub Pages deployment delays. You can download Artifacts in the Actions tab to view the HTMLExtra report immediately."
  
           curl -H "Content-Type: application/json" \
                -X POST \


### PR DESCRIPTION
Added timestamp.txt to reports on gh-pages so there'll always be changes to avoid skip or canceled run in actions. and also added a message on discord notification to notify PR author about the delay in github's pages and deploy ci run.