### PR TITLE
Wisdom/fix/changed the cleanup step 24-48 hours

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Git and CI
+.git
+.github/
+.gitignore
+ 
+# Environment and secrets
+.env
+*.env
+ 
+# Logs and temp files
+*.log
+*.tmp
+ 
+# IDE/editor clutter
+.vscode/
+.idea/
+*.swp
+.DS_Store
+ 
+# Composer build cache (safe to ignore in image)
+vendor/
+ 
+# Test and report artifacts
+reports/
+newman/
+coverage/
+ 
+# Node/npm stuff (only if present)
+node_modules/
+npm-debug.log
+ 
+# Ignore local-only override file if it ever exists
+docker-compose.override.yml

--- a/.github/workflows/Newman_backend_test.yaml
+++ b/.github/workflows/Newman_backend_test.yaml
@@ -652,9 +652,10 @@ jobs:
           git fetch origin gh-pages
           git checkout gh-pages
 
-      - name: Clean up old reports (older than 3 days)
+      - name: Clean up old reports (older than 1 day)
         run: |
-          find reports -mindepth 1 -maxdepth 1 -type d -mtime +3 -exec rm -rf {} +
+          echo "Cleaning old reports..."
+          find reports -mindepth 1 -maxdepth 1 -type d -mtime +1 -print -exec rm -rf {} +
  
       - name: Download HTMLExtra report for PHP 8.2
         uses: actions/download-artifact@v4
@@ -712,9 +713,10 @@ jobs:
           git fetch origin gh-pages
           git checkout gh-pages
 
-      - name: Clean up old reports (older than 3 days)
+      - name: Clean up old reports (older than 1 day)
         run: |
-          find reports -mindepth 1 -maxdepth 1 -type d -mtime +3 -exec rm -rf {} +
+          echo "Cleaning old reports..."
+          find reports -mindepth 1 -maxdepth 1 -type d -mtime +1 -print -exec rm -rf {} +
  
       - name: Download HTMLExtra report for PHP 8.2
         uses: actions/download-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM php:8.3-fpm-bookworm
  
-RUN apt-get update && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*
- 
-RUN apt-get update && apt-get install -y \
-    nginx supervisor \
-    git unzip curl libpq-dev postgresql-client \
-    openssl libzip-dev zlib1g-dev libxml2-dev \
-    libcurl4-openssl-dev libgmp-dev \
-    && docker-php-ext-install pgsql pdo pdo_pgsql bcmath xml curl gmp \
+RUN apt-get update && \
+    apt-get install -y \
+        nginx supervisor \
+        git unzip curl libpq-dev postgresql-client \
+        openssl libzip-dev zlib1g-dev libxml2-dev \
+        libcurl4-openssl-dev libgmp-dev \
+    && docker-php-ext-install \
+        pgsql pdo pdo_pgsql bcmath xml curl gmp \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
  
 RUN which supervisord


### PR DESCRIPTION
added .dockerignore, dpendencies and get update and install runs in one Run command in dockerfile, and changed the cleanup reports on gh-pages to be 24-48 hours.  aim for all this , is to not to consume space so htmlextra report can be live in discord