### PR TITLE
Fix Deprecated:  Base64FileHandler: :handleFileUpload(): Implicitly m…

### DIFF
--- a/src/GraphQLSchemaBuilder.php
+++ b/src/GraphQLSchemaBuilder.php
@@ -3119,9 +3119,9 @@ class GraphQLSchemaBuilder
         }
     }
 
-    protected function verifyAccount(string $userid = null): array
+    protected function verifyAccount(string $userid = ''): array
     {
-        if ($userid === null) {
+        if ($userid === '') {
             return $this->respondWithError(30101);
         }
 

--- a/src/Services/Base64FileHandler.php
+++ b/src/Services/Base64FileHandler.php
@@ -193,7 +193,7 @@ class Base64FileHandler
         return true;
     }
 
-    public function handleFileUpload(string $base64File, string $contentType, string $identifier, string $defaultSubfolder = null): array
+    public function handleFileUpload(string $base64File, string $contentType, string $identifier, string $defaultSubfolder = ''): array
     {
         if (!$this->isValidBase64Media($base64File, $contentType)) {
             return ['success' => false, 'error' => $this->errors];


### PR DESCRIPTION
This error: Deprecated:  Base64FileHandler: :handleFileUpload(): Implicitly marking parameter $defaultSubfolder as nullable is deprecated, the explicit nullable type must be used instead .

Throw when call ListPosts after updating the php version.

Fixed by replace nullable to string.