### PR TITLE
Update SQL Posts.Status Default: 0

### DIFF
--- a/sql_files_for_import/20250824000000_posts_status.sql
+++ b/sql_files_for_import/20250824000000_posts_status.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+-- Default ändern
+ALTER TABLE posts 
+    ALTER COLUMN status SET DEFAULT 0;
+
+-- Nur die bisherigen Werte von 10 auf 0 setzen
+UPDATE posts 
+    SET status = 0
+    WHERE status = 10;
+
+COMMIT;


### PR DESCRIPTION
-- Ändere den Standardwert der Spalte "status" in der Tabelle "posts"
-- Neuer Default = 0 (bisher war Default = 10)

-- Setze alle bestehenden Einträge, die aktuell noch status = 10 haben,
-- auf den neuen Wert status = 0

The default value of the status column in the posts table has been changed from 10 to 0.
All existing rows with status = 10 were updated to status = 0 to ensure consistency.
From now on, new posts will automatically have status = 0 unless another value is explicitly set.
