### PR TITLE
Added runtime-data logs as a volume to backend

### DIFF
--- a/Dockerfile.newman
+++ b/Dockerfile.newman
@@ -5,6 +5,6 @@ RUN npm install -g newman-reporter-htmlextra
  
 WORKDIR /etc/newman
 
-# Copy Postman collections and merge script into container
+# Copy Postman collections and merge script into container.
 COPY tests/postman_collection/*.json /etc/newman/
 COPY tests/postman_collection/merge-collections.js /etc/newman/

--- a/docker-compose.override.local.yml
+++ b/docker-compose.override.local.yml
@@ -29,6 +29,7 @@ services:
       timeout: 5s
       retries: 5
     volumes:
+      - ./src:/var/www/html/src
       - ./runtime-data/logs:/var/www/html/runtime-data/logs
     networks:
       - my-network

--- a/docker-compose.override.local.yml
+++ b/docker-compose.override.local.yml
@@ -28,9 +28,10 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    volumes:
+      - ./runtime-data/logs:/var/www/html/runtime-data/logs
     networks:
       - my-network
-
   newman:
     build:
       context: .


### PR DESCRIPTION
Added runtime-data logs as a volume to backend so logs can easily be viewed by devs in Git