### PR TITLE
changed parent image in dockerfile newman

### DIFF
--- a/Dockerfile.newman
+++ b/Dockerfile.newman
@@ -1,6 +1,7 @@
-FROM node:alpine
- 
-RUN npm install -g newman newman-reporter-htmlextra
+FROM postman/newman:alpine
+
+# Install HTMLExtra reporter
+RUN npm install -g newman-reporter-htmlextra
  
 WORKDIR /etc/newman
 


### PR DESCRIPTION
changed parent image in newman dockerfile , this image has node + newman preinstalled.  only htmlextra reporter is installed. solving the newman 403 error.