### PR TITLE
Wisdom/feat/makefile changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ test
 error
 srcc
 .env
+.env.ci
 .htaccess
 index.php
 psalm.xml

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ COMPOSE_FILES = -f docker-compose.yml $(if $(wildcard $(COMPOSE_OVERRIDE)),-f $(
 PROJECT_NAME ?= peer_backend_local_$(USER)
 export COMPOSE_PROJECT_NAME := $(PROJECT_NAME)
 
-env: ## Copy .env.dev to .env for local development
-	cp .env.dev .env
-	@echo ".env created from .env.dev"
+env-ci: ## Copy .env.dev to .env.ci for local development
+	cp .env.dev .env.ci
+	@echo ".env.ci created from .env.dev"
 
 init: ## Prepare Postman environment files for testing
 	@echo "Using sql_files_for_import/ directly"
@@ -28,7 +28,7 @@ init: ## Prepare Postman environment files for testing
 
 reset-db-and-backend: ## Reset DB, backend, and remove all related Docker images
 	@echo "Bringing down docker-compose stack with volumes..."
-	-@docker-compose $(COMPOSE_FILES) down -v
+	-@docker-compose --env-file .env.ci $(COMPOSE_FILES) down -v
 
 	@echo "Removing docker volume ..."
 	-@docker volume rm $(VOLUME_NAME) 2>/dev/null || echo "Volume $(VOLUME_NAME) already removed or in use."
@@ -47,10 +47,10 @@ reset-db-and-backend: ## Reset DB, backend, and remove all related Docker images
 
 reload-backend: ## Rebuild and restart backend container
 	@echo "Rebuilding backend image..."
-	docker-compose $(COMPOSE_FILES) build backend
+	docker-compose --env-file .env.ci $(COMPOSE_FILES) build backend
 
 	@echo "Recreating backend container..."
-	docker-compose $(COMPOSE_FILES) up -d --force-recreate backend
+	docker-compose --env-file .env.ci $(COMPOSE_FILES) up -d --force-recreate backend
 
 	@echo "Waiting for backend to be healthy..."
 	until curl -s -o /dev/null -w "%{http_code}" http://localhost:8888/graphql | grep -q "200"; do \
@@ -60,12 +60,12 @@ reload-backend: ## Rebuild and restart backend container
 
 restart-db: ## Restart only the database (fresh schema & data, keep backend as-is)
 	@echo "Stopping and removing only the DB container and volume..."
-	docker-compose $(COMPOSE_FILES) stop db
-	docker-compose $(COMPOSE_FILES) rm -f db
+	docker-compose --env-file .env.ci $(COMPOSE_FILES) stop db
+	docker-compose --env-file .env.ci $(COMPOSE_FILES) rm -f db
 	docker volume rm $(VOLUME_NAME) 2>/dev/null || echo "DB volume already removed."
 
 	@echo "Recreating fresh DB..."
-	docker-compose $(COMPOSE_FILES) up -d db
+	docker-compose --env-file .env.ci $(COMPOSE_FILES) up -d db
 
 	@echo "Waiting for Postgres healthcheck..."
 	until [ "$$(docker inspect --format='{{.State.Health.Status}}' $$(docker-compose $(COMPOSE_FILES) ps -q db))" = "healthy" ]; do \
@@ -74,7 +74,7 @@ restart-db: ## Restart only the database (fresh schema & data, keep backend as-i
 
 	@echo "Database restarted and ready. Backend container was untouched."
 
-dev: env reset-db-and-backend init ## Full setup: env, DB reset, vendors install, start DB+backend
+dev: env-ci reset-db-and-backend init ## Full setup: env.ci, DB reset, vendors install, start DB+backend
 	@echo "Installing Composer dependencies on local host..."
 	composer install --no-dev --prefer-dist --no-interaction
 
@@ -91,18 +91,18 @@ dev: env reset-db-and-backend init ## Full setup: env, DB reset, vendors install
 	find . -type f -exec chmod 666 {} \;
 
 	@echo "Building images..."
-	docker-compose $(COMPOSE_FILES) build
+	docker-compose --env-file .env.ci -f docker-compose.yml -f docker-compose.override.local.yml build
 
 	@echo "Starting DB..."
-	docker-compose $(COMPOSE_FILES) up -d db
+	docker-compose --env-file .env.ci -f docker-compose.yml -f docker-compose.override.local.yml up -d db
 
 	@echo "Waiting for Postgres to be healthy..."
-	until docker-compose $(COMPOSE_FILES) exec db pg_isready -U postgres | grep -q "accepting connections"; do \
+	until docker-compose --env-file .env.ci -f docker-compose.yml -f docker-compose.override.local.yml exec db pg_isready -U postgres | grep -q "accepting connections"; do \
 		echo "Waiting for DB..."; sleep 2; \
 	done
 
 	@echo "Starting backend..."
-	docker-compose $(COMPOSE_FILES) up -d backend
+	docker-compose --env-file .env.ci -f docker-compose.yml -f docker-compose.override.local.yml up -d backend
 	
 	@echo "Waiting for backend to be healthy..."
 	until curl -s -o /dev/null -w "%{http_code}" http://localhost:8888/graphql | grep -q "200"; do \
@@ -113,10 +113,10 @@ dev: env reset-db-and-backend init ## Full setup: env, DB reset, vendors install
 
 restart: ## Soft restart with fresh DB but keep current code & vendors
 	@echo "Stopping and removing Docker stack (incl. volumes)..."
-	docker-compose $(COMPOSE_FILES) down -v
+	docker-compose --env-file .env.ci $(COMPOSE_FILES) down -v
 
 	@echo "Docker stack removed. Starting fresh DB + Backend with existing code & vendors..."
-	docker-compose $(COMPOSE_FILES) up -d db
+	docker-compose --env-file .env.ci $(COMPOSE_FILES) up -d db
 
 	@echo "Waiting for Postgres healthcheck..."
 	until [ "$$(docker inspect --format='{{.State.Health.Status}}' $$(docker-compose $(COMPOSE_FILES) ps -q db))" = "healthy" ]; do \
@@ -124,7 +124,7 @@ restart: ## Soft restart with fresh DB but keep current code & vendors
 	done
 
 	@echo "Starting backend with current code..."
-	docker-compose $(COMPOSE_FILES) up -d backend
+	docker-compose --env-file .env.ci $(COMPOSE_FILES) up -d backend
 
 	@echo "Waiting for backend to be healthy..."
 	until curl -s -o /dev/null -w "%{http_code}" http://localhost:8888/graphql | grep -q "200"; do \
@@ -141,13 +141,13 @@ ensure-jq: ## Ensure jq is installed (auto-install if missing)
 
 test: ensure-jq ## Run Newman tests inside Docker and generate HTML report
 	@echo "Building Newman container..."
-	docker-compose $(COMPOSE_FILES) build newman
+	docker-compose --env-file .env.ci -f docker-compose.yml -f docker-compose.override.local.yml build newman
 
 	@echo "Starting Newman container..."
-	docker-compose $(COMPOSE_FILES) up -d newman
+	docker-compose --env-file .env.ci -f docker-compose.yml -f docker-compose.override.local.yml up -d newman
 
 	@echo "Running merge script inside the container..."
-	docker-compose $(COMPOSE_FILES) run --rm newman \
+	docker-compose --env-file .env.ci -f docker-compose.yml -f docker-compose.override.local.yml run --rm newman \
 		node /etc/newman/merge-collections.js
 
 	jq '(.item[] | select(.request.url.raw != null) | .request.url) |= {raw: "{{BACKEND_URL}}/graphql", protocol: "http", host: ["backend"], path: ["graphql"]}' \
@@ -163,7 +163,7 @@ test: ensure-jq ## Run Newman tests inside Docker and generate HTML report
 	mv -f tests/postman_collection/tmp_env_patched.json tests/postman_collection/tmp_env.json
 
 	@echo "Running Newman tests inside the container..."
-	docker-compose $(COMPOSE_FILES) run --rm newman \
+	docker-compose --env-file .env.ci -f docker-compose.yml -f docker-compose.override.local.yml run --rm newman \
 	    newman run /etc/newman/tmp_collection.json \
 	    --environment /etc/newman/tmp_env.json \
 	    --reporters cli,htmlextra \
@@ -196,29 +196,39 @@ clean-all: reset-db-and-backend  ## Remove containers, volumes, vendors, reports
 		echo "Could not remove newman folder (report.html). Might need sudo or manual cleanup."; \
 		true; \
 	}
-	@rm -f .env
+	@rm -f .env.ci
 	@rm -f supervisord.pid
 	@rm -f runtime-data/logs/errorlog.txt
 	@rm -f tests/postman_collection/tmp_*.json
 	@echo "Local project cleanup complete."
 
+clean-ci: reset-db-and-backend ## Cleanup for CI but keep reports
+	@rm -f composer.lock
+	@rm -rf vendor
+	@rm -rf sql_files_for_import_tmp
+	@rm -f .env.ci
+	@rm -f supervisord.pid
+	@rm -f runtime-data/logs/errorlog.txt
+	@rm -f tests/postman_collection/tmp_*.json
+	@echo "Local CI cleanup complete (reports preserved)."
+
 ci: ## Run full local CI workflow (setup, tests, cleanup)
 	$(MAKE) dev
 	$(MAKE) test
-	$(MAKE) clean-all
+	$(MAKE) clean-ci
 
 # ---- Developer Shortcuts ----
 .PHONY: logs db bash-backend
 
 logs: ## Tail backend container logs
-	@docker-compose $(COMPOSE_FILES) logs -f backend
+	@docker-compose --env-file .env.ci $(COMPOSE_FILES) logs -f backend
 
 db: ## Open psql shell into Postgres
-	@docker-compose $(COMPOSE_FILES) exec -e PGPASSWORD=$(DB_PASSWORD) db \
+	@docker-compose --env-file .env.ci $(COMPOSE_FILES) exec -e PGPASSWORD=$(DB_PASSWORD) db \
 	    psql -h $(DB_HOST) -U $(DB_USERNAME) -d $(DB_DATABASE)
 
 bash-backend: ## Open interactive shell in backend container
-	@docker-compose $(COMPOSE_FILES) exec backend bash
+	@docker-compose --env-file .env.ci $(COMPOSE_FILES) exec backend bash
 
 help: ## Show available make targets
 	@echo "Available targets:"

--- a/README_local_ci.md
+++ b/README_local_ci.md
@@ -225,11 +225,12 @@ Available targets:
 bash-backend : Open interactive shell in backend container
 ci : Run full local CI workflow (setup, tests, cleanup)
 clean-all : Remove containers, volumes, vendors, reports, logs
+clean-ci : Cleanup for CI but keep reports
 clean-prune : Remove ALL unused images, build cache, and volumes
 db : Open psql shell into Postgres
 dev : Full setup: env, DB reset, vendors install, start DB+backend
 ensure-jq : Ensure jq is installed (auto-install if missing)
-env : Copy .env.dev to .env for local development
+env-ci : Copy .env.dev to .env.ci for local development
 help : Show available make targets
 init : Prepare Postman environment files for testing
 logs : Tail backend container logs

--- a/README_local_ci.md
+++ b/README_local_ci.md
@@ -15,6 +15,7 @@ Make sure you have the following installed:
 - jq
 - composer
 - curl
+- php (required only for Composer on host; e.g. sudo apt install php-cli on Ubuntu/WSL, or brew install php on macOS. Backend itself runs in Docker.)
 
 (If `jq` is missing, `make` will auto-install it on Ubuntu/WSL via `sudo apt install jq`.)
 
@@ -42,7 +43,7 @@ make dev
 
 This will:
 
-- Create `.env` from `.env.dev`  
+- Create `.env.ci` from `.env.dev`  
 - Reset Docker containers, images and volumes (full clean)  
 - Copy SQL files and Postman test files  
 - Install PHP dependencies via composer on your host  
@@ -123,7 +124,23 @@ This will:
 
 ---
 
-### 7. Full Cleanup
+### 7a. CI Cleanup (keep reports)
+
+If you want to clean up your local CI run but keep generated reports (so you can still view the HTMLExtra results), run:
+
+```bash
+make clean-ci
+```
+This will:
+
+- Stop Docker containers and remove volumes
+- Delete .env.ci, vendor/, temp SQL, and temp Postman JSON files
+- Preserve HTML test reports
+- This is the cleanup step that make ci calls at the end of its run.
+
+---
+
+### 7b. Full Cleanup
 
 To stop and remove everything (containers, volumes, files):
 
@@ -134,7 +151,7 @@ make clean-all
 This will:
 
 - Stop Docker containers and remove volumes
-- Delete `.env`, `vendor/`, temp SQL, Postman tmp files, reports, logs
+- Delete `.env.ci`, `vendor/`, temp SQL, Postman tmp files, reports, logs
 
 ---
 
@@ -152,7 +169,15 @@ This will:
 - Execute the Newman test suite with the same Postman collections as remote CI
 - Generate an HTML report of the test results
 - Skip interactive steps so it can run unattended
-- Clean up containers, volumes, and temp files automatically at the end
+- Run make clean-ci at the end (removes containers, volumes, vendors, tmp files, etc. but preserves reports so you can view them)
+
+⚠️ Important: After reviewing your report, run:
+
+```bash
+make clean-all
+```
+
+This ensures your environment is fully cleaned (reports, vendors, and temp files) before the next run.
 
 ---
 


### PR DESCRIPTION
made some big changes to Makefile and Documented them in readme local.
introduced .env.ci flow:
make dev now copies .env.dev into .env.ci (instead of overwriting .env).
Keeps developers’ personal .env untouched, so local Postman or custom setups are safe, so they can always run there environments whenever.
Standardized docker-compose usage with --env-file .env.ci.
Ensured composer install runs on the host (requires PHP installed locally, backend itself still runs inside Docker).
Split cleanup logic:
make clean-ci → used at the end of make ci (removes containers, volumes, tmp files, vendors, etc. but preserves reports).
make clean-all → full cleanup (also deletes reports, vendors, logs).
Improved reset/restart targets (reset-db-and-backend, reload-backend, restart-db) to consistently use .env.ci.
.env.ci is now gitignored.

Documentation Updates
Rewrote README_local_CI.md:
Clarified prerequisites (Docker, Composer, PHP required only for Composer).
Added explicit PHP installation hints for WSL/macOS users.
Explained new .env.ci workflow (no more overwriting .env).
Documented clean-ci vs clean-all clearly.
Highlighted that make ci runs clean-ci at the end, but devs should follow up with make clean-all after reviewing reports.
Expanded sections on developer shortcuts (logs, db, bash-backend).
Added detailed examples for make help output. for 7a
Confirmed that newman/reports is gitignored (reports can’t accidentally be committed).