### PR TITLE
to send depandabot message on updates to discord channel

### DIFF
--- a/.github/workflows/dependabot-update-alerts.yml
+++ b/.github/workflows/dependabot-update-alerts.yml
@@ -1,0 +1,40 @@
+name: Dependabot Update Alerts
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    branches:
+      - development
+      - main
+      - pre-release
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  notify_dependabot_update:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Discord Notification
+        run: |
+          MESSAGE=":package: **Dependabot opened an Update PR**\n"
+          MESSAGE+="**Title:** ${{ github.event.pull_request.title }}\n"
+          MESSAGE+="**Link:** ${{ github.event.pull_request.html_url }}\n"
+          MESSAGE+="**Branch:** ${{ github.event.pull_request.head.ref }}\n"
+          MESSAGE+="Opened by: Dependabot"
+          curl -H "Content-Type: application/json" \
+               -X POST \
+               -d "{\"content\": \"$MESSAGE\"}" \
+               "${{ secrets.DISCORD_WEBHOOK_DEPENDABOT }}"
+
+      - name: Install GitHub CLI
+        run: sudo apt-get install -y gh
+
+      - name: Add label to PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pr_number=${{ github.event.pull_request.number }}
+          gh pr edit "$pr_number" --add-label "dependabot-update-alert"


### PR DESCRIPTION
Added a workflow to send Alert to depandabot discord channel when there is a PR triggered by depandabot on an update on  docker, composer ,php, github actions. this helps to know about the updates if devs doesn’t see the PR.