### PR TITLE
Wisdom/fix/local compose env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
-# Load .env file
+# Warn if .env file exists (Docker Compose auto-loads .env by default)
 ifneq (,$(wildcard .env))
-    include .env
-    export
+    $(warning Local .env detected. Docker Compose auto-loads this and it may override .env.ci. To avoid issues, either delete it or set COMPOSE_ENV_FILE=.env.ci)
 endif
 
 IMAGE_TAG=local
 export IMAGE_TAG
+
+# Force Docker Compose to use .env.ci instead of auto-loading .env
+export COMPOSE_ENV_FILE=.env.ci
 
 VOLUME_NAME = $(COMPOSE_PROJECT_NAME)_db_data
 COMPOSE_OVERRIDE = docker-compose.override.local.yml

--- a/docker-compose.override.local.yml
+++ b/docker-compose.override.local.yml
@@ -28,6 +28,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    environment:
+      DB_HOST: db
     volumes:
       - ./src:/var/www/html/src
       - ./runtime-data/logs:/var/www/html/runtime-data/logs


### PR DESCRIPTION
Set DB_HOST=db in backend service to avoid fallback to localhost.
Forced Docker Compose to always use .env.ci (export COMPOSE_ENV_FILE=.env.ci).
Added Makefile check/warning if .env is present to prevent accidental overrides.