### PR TITLE
Wisdom/feat/make ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,24 @@ GITLEAKS_VERSION = 8.28.0
 IMAGE_TAG=local
 export IMAGE_TAG
 
+# Default DB_PORT behavior — only print once at top-level call
+ifeq ($(MAKELEVEL),0)
+  ifeq ($(MAKECMDGOALS),ci2)
+    export DB_PORT :=
+    $(info Running CI2 mode → DB_PORT is unset (internal only))
+  else
+    export DB_PORT = 5432
+    $(info Running DEV mode → DB_PORT=$(DB_PORT))
+  endif
+else
+  # Nested make: still set DB_PORT but skip info output
+  ifeq ($(MAKECMDGOALS),ci2)
+    export DB_PORT :=
+  else
+    export DB_PORT = 5432
+  endif
+endif
+
 # Force Docker Compose to use .env.ci instead of auto-loading .env
 export COMPOSE_ENV_FILE=.env.ci
 
@@ -17,6 +35,16 @@ COMPOSE_FILES = -f docker-compose.yml $(if $(wildcard $(COMPOSE_OVERRIDE)),-f $(
 
 PROJECT_NAME ?= peer_backend_local_$(shell echo $(USER) | tr '[:upper:]' '[:lower:]')
 export COMPOSE_PROJECT_NAME := $(PROJECT_NAME)
+
+export CI2_PROJECT_NAME=$(COMPOSE_PROJECT_NAME)_ci2
+
+# Compose file sets
+COMPOSE_BASE = -f docker-compose.yml
+COMPOSE_LOCAL = $(COMPOSE_BASE) -f docker-compose.override.local.yml
+COMPOSE_CI = $(COMPOSE_BASE) -f docker-compose.override.ci.yml
+
+# Default to COMPOSE_LOCAL if COMPOSE_FILES not overridden
+COMPOSE_FILES ?= $(COMPOSE_LOCAL)
 
 env-ci: ## Copy .env.dev to .env.ci for local development
 	cp .env.dev .env.ci
@@ -32,7 +60,7 @@ init: ## Prepare Postman environment files for testing
 
 reset-db-and-backend: ## Reset DB, backend, and remove all related Docker images
 	@echo "Bringing down docker-compose stack with volumes..."
-	-@docker-compose --env-file .env.ci $(COMPOSE_FILES) down -v
+	-@docker-compose --env-file "./.env.ci" $(COMPOSE_FILES) down -v
 
 	@echo "Removing docker volume ..."
 	-@docker volume rm $(VOLUME_NAME) 2>/dev/null || echo "Volume $(VOLUME_NAME) already removed or in use."
@@ -51,10 +79,10 @@ reset-db-and-backend: ## Reset DB, backend, and remove all related Docker images
 
 reload-backend: ## Rebuild and restart backend container
 	@echo "Rebuilding backend image..."
-	docker-compose --env-file .env.ci $(COMPOSE_FILES) build backend
+	docker-compose --env-file "./.env.ci" $(COMPOSE_FILES) build backend
 
 	@echo "Recreating backend container..."
-	docker-compose --env-file .env.ci $(COMPOSE_FILES) up -d --force-recreate backend
+	docker-compose --env-file "./.env.ci" $(COMPOSE_FILES) up -d --force-recreate backend
 
 	@echo "Waiting for backend to be healthy..."
 	until curl -s -o /dev/null -w "%{http_code}" http://localhost:8888/graphql | grep -q "200"; do \
@@ -64,13 +92,12 @@ reload-backend: ## Rebuild and restart backend container
 
 restart-db: ## Restart only the database (fresh schema & data, keep backend as-is)
 	@echo "Stopping and removing only the DB container and volume..."
-	docker-compose --env-file .env.ci $(COMPOSE_FILES) stop db
-	docker-compose --env-file .env.ci $(COMPOSE_FILES) rm -f db
+	docker-compose --env-file "./.env.ci" $(COMPOSE_FILES) stop db
+	docker-compose --env-file "./.env.ci" $(COMPOSE_FILES) rm -f db
 	docker volume rm $(VOLUME_NAME) 2>/dev/null || echo "DB volume already removed."
 
 	@echo "Recreating fresh DB..."
-	docker-compose --env-file .env.ci $(COMPOSE_FILES) up -d db
-
+	+ docker-compose --env-file "./.env.ci" $(COMPOSE_FILES) up -d db
 	@echo "Waiting for Postgres healthcheck..."
 	until [ "$$(docker inspect --format='{{.State.Health.Status}}' $$(docker-compose $(COMPOSE_FILES) ps -q db))" = "healthy" ]; do \
 		echo "Waiting for DB..."; sleep 2; \
@@ -98,18 +125,18 @@ dev: env-ci reset-db-and-backend init check-hooks scan ## Full setup: env.ci, DB
 	chmod +x .githooks/*
 
 	@echo "Building images..."
-	docker-compose --env-file .env.ci -f docker-compose.yml -f docker-compose.override.local.yml build
+	docker-compose --env-file "./.env.ci" -f docker-compose.yml -f docker-compose.override.local.yml build
 
 	@echo "Starting DB..."
-	docker-compose --env-file .env.ci -f docker-compose.yml -f docker-compose.override.local.yml up -d db
+	docker-compose --env-file "./.env.ci" -f docker-compose.yml -f docker-compose.override.local.yml up -d db
 
 	@echo "Waiting for Postgres to be healthy..."
-	until docker-compose --env-file .env.ci -f docker-compose.yml -f docker-compose.override.local.yml exec db pg_isready -U postgres | grep -q "accepting connections"; do \
+	until docker-compose --env-file "./.env.ci" -f docker-compose.yml -f docker-compose.override.local.yml exec db pg_isready -U postgres | grep -q "accepting connections"; do \
 		echo "Waiting for DB..."; sleep 2; \
 	done
 
 	@echo "Starting backend..."
-	docker-compose --env-file .env.ci -f docker-compose.yml -f docker-compose.override.local.yml up -d backend
+	docker-compose --env-file "./.env.ci" -f docker-compose.yml -f docker-compose.override.local.yml up -d backend
 	
 	@echo "Waiting for backend to be healthy..."
 	until curl -s -o /dev/null -w "%{http_code}" http://localhost:8888/graphql | grep -q "200"; do \
@@ -146,15 +173,15 @@ ensure-jq: ## Ensure jq is installed (auto-install if missing)
 		sudo apt update && sudo apt install -y jq; \
 	}
 
-test: ensure-jq ## Run Newman tests inside Docker and generate HTML report
+test: env-ci init ensure-jq ## Run Newman tests inside Docker and generate HTML report
 	@echo "Building Newman container..."
-	docker-compose --env-file .env.ci -f docker-compose.yml -f docker-compose.override.local.yml build newman
+	docker-compose --env-file "./.env.ci" $(COMPOSE_FILES) build newman
 
 	@echo "Starting Newman container..."
-	docker-compose --env-file .env.ci -f docker-compose.yml -f docker-compose.override.local.yml up -d newman
+	docker-compose --env-file "./.env.ci" $(COMPOSE_FILES) up -d newman
 
 	@echo "Running merge script inside the container..."
-	docker-compose --env-file .env.ci -f docker-compose.yml -f docker-compose.override.local.yml run --rm newman \
+	docker-compose --env-file "./.env.ci" $(COMPOSE_FILES) run --rm newman \
 		node /etc/newman/merge-collections.js
 
 	jq '(.item[] | select(.request.url.raw != null) | .request.url) |= {raw: "{{BACKEND_URL}}/graphql", protocol: "http", host: ["backend"], path: ["graphql"]}' \
@@ -170,7 +197,7 @@ test: ensure-jq ## Run Newman tests inside Docker and generate HTML report
 	mv -f tests/postman_collection/tmp_env_patched.json tests/postman_collection/tmp_env.json
 
 	@echo "Running Newman tests inside the container..."
-	docker-compose --env-file .env.ci -f docker-compose.yml -f docker-compose.override.local.yml run --rm newman \
+	docker-compose --env-file .env.ci $(COMPOSE_FILES) run --rm newman \
 	    newman run /etc/newman/tmp_collection.json \
 	    --environment /etc/newman/tmp_env.json \
 	    --reporters cli,htmlextra \
@@ -195,7 +222,15 @@ test: ensure-jq ## Run Newman tests inside Docker and generate HTML report
 	}
 	
 
-clean-all: reset-db-and-backend  ## Remove containers, volumes, vendors, reports, logs
+clean-all: ## Remove containers, volumes, vendors, reports, logs
+	@echo "Cleaning full local environment (dev + ci2)..."
+
+	@echo "→ Cleaning CI artifacts (includes dev DB reset)..."
+	$(MAKE) --no-print-directory clean-ci
+
+	@echo "→ Cleaning CI2 environment..."
+	$(MAKE) --no-print-directory clean-ci2
+
 	@rm -f composer.lock
 	@rm -rf vendor
 	@rm -rf sql_files_for_import_tmp
@@ -208,7 +243,8 @@ clean-all: reset-db-and-backend  ## Remove containers, volumes, vendors, reports
 	@rm -f supervisord.pid
 	@rm -f runtime-data/logs/errorlog.txt
 	@rm -f tests/postman_collection/tmp_*.json
-	@echo "Local project cleanup complete."
+
+	@echo "Local project cleanup complete (dev + ci + ci2)."
 
 clean-ci: reset-db-and-backend ## Cleanup for CI but keep reports
 	@rm -f composer.lock
@@ -224,6 +260,94 @@ ci: check-hooks ## Run full local CI workflow (setup, tests, cleanup)
 	$(MAKE) dev
 	$(MAKE) test
 	$(MAKE) clean-ci
+
+clean-ci2: ## Cleanup for isolated CI2 environment but keep reports
+	@echo "Cleaning up CI2 environment (preserving Newman reports)..."
+	CI2_PROJECT_NAME=$(COMPOSE_PROJECT_NAME)_ci2
+
+	@echo "Stopping and removing CI2 containers, networks, and volumes..."
+	COMPOSE_PROJECT_NAME=$${CI2_PROJECT_NAME} docker-compose --env-file .env.ci $(COMPOSE_CI) down --remove-orphans || true
+
+	@echo "Removing CI2 DB volume..."
+	-@docker volume rm $$(docker volume ls -q | grep -E "^.*${CI2_PROJECT_NAME}.*db_data$$") 2>/dev/null || true
+
+	@echo "Removing temp & build artifacts (keeping reports)..."
+	@rm -f composer.lock
+	@rm -rf vendor sql_files_for_import_tmp
+	@rm -f .env.ci supervisord.pid runtime-data/logs/errorlog.txt
+	@rm -f tests/postman_collection/tmp_*.json
+	@echo "CI2 cleanup complete — Newman reports preserved."
+
+ci2: check-hooks env-ci init ## Run full isolated local CI2 workflow (setup, tests, cleanup)
+	@echo "Checking for running dev DB container on port 5432..."
+	@if docker ps --format '{{.Names}} {{.Ports}}' | grep -q 'peer_backend_local_$(shell echo $(USER) | tr "[:upper:]" "[:lower:]")-db-1.*5432'; then \
+		echo "Detected dev DB container using port 5432. Stopping it temporarily..."; \
+		docker stop peer_backend_local_$(shell echo $(USER) | tr "[:upper:]" "[:lower:]")-db-1 >/dev/null || true; \
+		echo "Dev DB stopped to free port 5432."; \
+	else \
+		echo "No dev DB container running on port 5432."; \
+	fi
+
+	@echo "Checking for running dev backend container on port 8888..."
+	@if docker ps --format '{{.Names}} {{.Ports}}' | grep -q 'peer_backend_local_$(shell echo $(USER) | tr "[:upper:]" "[:lower:]")-backend-1.*8888'; then \
+		echo "Detected dev backend container using port 8888. Stopping it temporarily..."; \
+		docker stop peer_backend_local_$(shell echo $(USER) | tr "[:upper:]" "[:lower:]")-backend-1 >/dev/null || true; \
+		echo "Dev backend stopped to free port 8888."; \
+	else \
+		echo "No dev backend container running on port 8888."; \
+	fi
+
+	@echo "Starting isolated CI2 environment..."
+	CI2_PROJECT_NAME=$(COMPOSE_PROJECT_NAME)_ci2
+
+	@echo "Removing any old CI2 volumes..."
+	-@docker volume rm $$(docker volume ls -q | grep "$${CI2_PROJECT_NAME}.*db_data") 2>/dev/null || true
+
+	@echo "Building CI2 images..."
+	COMPOSE_PROJECT_NAME=$${CI2_PROJECT_NAME} docker-compose --env-file .env.ci \
+		-f docker-compose.yml \
+		-f docker-compose.override.ci.yml \
+		build
+
+	@echo "Starting CI2 stack (db + backend)..."
+	COMPOSE_PROJECT_NAME=$${CI2_PROJECT_NAME} docker-compose --env-file .env.ci \
+		-f docker-compose.yml \
+		-f docker-compose.override.ci.yml \
+		up -d db backend
+
+	@echo "Waiting for DB healthcheck..."
+	until [ "$$(docker inspect --format='{{.State.Health.Status}}' \
+		$$(COMPOSE_PROJECT_NAME=$${CI2_PROJECT_NAME} docker-compose --env-file .env.ci \
+		-f docker-compose.yml -f docker-compose.override.ci.yml ps -q db))" = "healthy" ]; do \
+		echo "Waiting for DB..."; sleep 2; \
+	done
+
+	@echo "Waiting for backend healthcheck..."
+	until COMPOSE_PROJECT_NAME=$${CI2_PROJECT_NAME} docker-compose --env-file .env.ci \
+		-f docker-compose.yml -f docker-compose.override.ci.yml \
+		exec backend curl -sf http://localhost/graphql >/dev/null; do \
+		echo "Waiting for backend..."; sleep 2; \
+	done
+
+	@echo "Running Newman tests (under isolated CI2 stack)..."
+	CI2_PROJECT_NAME=$${CI2_PROJECT_NAME} \
+	COMPOSE_PROJECT_NAME=$${CI2_PROJECT_NAME} \
+	$(MAKE) test COMPOSE_FILES="-f docker-compose.yml -f docker-compose.override.ci.yml" \
+	COMPOSE_PROJECT_NAME=$${CI2_PROJECT_NAME}
+
+	@echo "Cleaning up CI2 containers and volumes..."
+	$(MAKE) clean-ci2
+
+	@echo "Restarting previously stopped dev containers (if any)..."
+	@docker start peer_backend_local_$(shell echo $(USER) | tr "[:upper:]" "[:lower:]")-db-1 >/dev/null 2>&1 \
+		&& echo "Dev DB restarted." \
+		|| echo "No previously stopped dev DB to restart."
+
+	@docker start peer_backend_local_$(shell echo $(USER) | tr "[:upper:]" "[:lower:]")-backend-1 >/dev/null 2>&1 \
+		&& echo "Dev backend restarted." \
+		|| echo "No previously stopped dev backend to restart."
+
+	@echo "CI2 run complete — Dev containers preserved and ports 5432 & 8888 restored."
 
 # ---- Developer Shortcuts ----
 .PHONY: logs db bash-backend
@@ -251,6 +375,7 @@ clean-prune: clean-all ## Remove ALL unused images, build cache, and volumes
 hot-ci:
 	$(MAKE) restart-db
 	$(MAKE) test
+
 ensure-gitleaks: ## Ensure Gitleaks is installed locally (auto-install if missing)
 	@if command -v gitleaks >/dev/null 2>&1; then \
 		echo "Gitleaks already installed: $$(gitleaks version)"; \

--- a/README_local_ci.md
+++ b/README_local_ci.md
@@ -212,7 +212,27 @@ This will:
 - Skip interactive steps so it can run unattended
 - Run make clean-ci at the end (removes containers, volumes, vendors, tmp files, etc. but preserves reports so you can view them)
 
-⚠️ Important: After reviewing your report, run:
+---
+### 8b. Run Isolated Local CI2 Environment (Preserve Dev Containers & Volumes)
+If you want to run a full CI-like test without affecting your local development stack, use:
+
+```bash
+make ci2
+```
+This will:
+
+- Detect if your local make dev stack (backend + Postgres) is running
+- Temporarily stop the dev containers (to free ports 5432 and 8888)
+- Spin up an isolated CI2 environment with its own containers, networks, and volumes
+- These are automatically prefixed with _ci2 (e.g. peer_backend_local_<user>_ci2-db-1)
+- Run the full Newman test suite inside that isolated CI2 stack
+- Clean up only CI2 containers, networks, and volumes after the tests
+- Automatically restart your original dev containers once CI2 finishes
+- Preserve your dev database volume and data
+
+This allows you to test a clean CI setup locally without wiping or touching your dev data.
+
+⚠️ Important: After reviewing your report from Ci or Ci2, run:
 
 ```bash
 make clean-all
@@ -264,9 +284,11 @@ Example output:
 
 Available targets:
 bash-backend : Open interactive shell in backend container
-check-hooks               Verify that Git hooks are installed and executable
+check-hooks : Verify that Git hooks are installed and executable
+ci2 : Run full isolated local CI2 workflow (setup, tests, cleanup)
 ci : Run full local CI workflow (setup, tests, cleanup)
 clean-all : Remove containers, volumes, vendors, reports, logs
+clean-ci2 : Cleanup for isolated CI2 environment but keep reports
 clean-ci : Cleanup for CI but keep reports
 clean-prune : Remove ALL unused images, build cache, and volumes
 db : Open psql shell into Postgres

--- a/docker-compose.override.ci.yml
+++ b/docker-compose.override.ci.yml
@@ -1,0 +1,60 @@
+x-project-name: &project_name "${COMPOSE_PROJECT_NAME}-ci"
+services:
+  db:
+    ports: []
+    volumes:
+      - ./sql_files_for_import:/docker-entrypoint-initdb.d
+      - db_data_ci:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    networks:
+      - ci-network
+      
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.local
+      args:
+        IMAGE_TAG: ${IMAGE_TAG}
+    image: peer-backend-ci:${IMAGE_TAG}
+    depends_on:
+      db:
+        condition: service_healthy
+    ports: []
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/graphql"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    environment:
+      DB_HOST: db
+    volumes:
+      - ./src:/var/www/html/src
+      - ./runtime-data/logs:/var/www/html/runtime-data/logs
+      - ./runtime-data/media/assets:/var/www/html/runtime-data/media/assets
+    networks:
+      - ci-network
+  newman:
+    build:
+      context: .
+      dockerfile: Dockerfile.newman
+    volumes:
+      - ./tests/postman_collection:/etc/newman
+      - ./tests/media_files:/etc/newman/media_files
+      - ./newman/reports:/etc/newman/reports
+    entrypoint: []
+    command: tail -f /dev/null
+    mem_limit: 2g
+    networks:
+      - ci-network
+
+networks:
+  ci-network:
+    name: "${COMPOSE_PROJECT_NAME}_ci2_network"
+
+volumes:
+  db_data_ci:
+    name: "${COMPOSE_PROJECT_NAME}_ci2_db_data"


### PR DESCRIPTION
added make ci2 for a separate  ci run that doesn’t delete containers and volume from make dev.  devs can run make dev and have there containers and volume up so they can make changes to there codes without killing the containers and volume. they can simply run a make ci2 command that starts up different containers and volume and kills it after running . make clean-all will delete the reports.  explained in the local Read me 